### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ MiSTerClaw might be the first MCP server for MiSTer-FPGA. Control your MiSTer fr
 ![License](https://img.shields.io/badge/License-MIT-green)
 ![Platform](https://img.shields.io/badge/Platform-ARMv7_(DE10--Nano)-blue)
 
+[![MiSTerClaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/card.svg)](https://glama.ai/mcp/servers/catallo/misterclaw)
+
 ## What is this?
 
 MiSTerClaw lets AI agents — Claude, ChatGPT, OpenClaw, Hermes, Cursor, and others — control a MiSTer-FPGA over the network. Launch games, search your ROM library, take screenshots, manage the system, and even set up Tailscale VPN for secure remote access from anywhere. It uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) standard, so any MCP-compatible client works out of the box. For agents without MCP support, a CLI client is also included.


### PR DESCRIPTION
This PR adds a badge for the [MiSTerClaw](https://glama.ai/mcp/servers/catallo/misterclaw) server listing in Glama MCP server directory.

[![MiSTerClaw MCP server](https://glama.ai/mcp/servers/catallo/misterclaw/badges/card.svg)](https://glama.ai/mcp/servers/catallo/misterclaw)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.